### PR TITLE
lisätään prefiksejä ja poistetaan vieraita kieliarvoja finafista

### DIFF
--- a/vocabularies/finaf/finaf-metadata.ttl
+++ b/vocabularies/finaf/finaf-metadata.ttl
@@ -6,10 +6,15 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 @prefix finaf: <http://urn.fi/URN:NBN:fi:au:finaf:>.
+@prefix mts: <http://urn.fi/URN:NBN:fi:au:mts:>.
 @prefix rdaa: <http://rdaregistry.info/Elements/a/> .
 @prefix rdac: <http://rdaregistry.info/Elements/c/> .
+@prefix rdae: <http://rdaregistry.info/Elements/e/> .
+@prefix rdam: <http://rdaregistry.info/Elements/m/> .
+@prefix rdan: <http://rdaregistry.info/Elements/n/> .
 @prefix rdau: <http://rdaregistry.info/Elements/u/> .
 @prefix rdaw: <http://rdaregistry.info/Elements/w/> .
+@prefix rdax: <http://rdaregistry.info/Elements/x/> .
 
 finaf: a skos:ConceptScheme ;
     dc:creator "National Library of Finland"@en,

--- a/vocabularies/finaf/finaf.cfg
+++ b/vocabularies/finaf/finaf.cfg
@@ -22,9 +22,16 @@ update_query=
 	DELETE {
 	  ?a ?prop ?label .
 	} WHERE {
-          VALUES ?prop { rdfs:label skos:definition reg:name rdakit:toolkitLabel rdakit:toolkitDefinition }
+        {
+          VALUES ?prop { rdfs:label skos:definition skos:scopeNote reg:name rdakit:toolkitLabel rdakit:toolkitDefinition }
           ?a ?prop ?label .
           FILTER (LANG(?label) != 'fi' && LANG(?label) != 'sv' && LANG(?label) != 'en')
+        } UNION {
+          VALUES ?prop { reg:lexicalAlias }
+          ?a ?prop ?label .
+          BIND (STR(?label) as ?striri)
+          FILTER (!STRENDS(?striri, '.fi') && !STRENDS(?striri, '.sv') && !STRENDS(?striri, '.en'))
+        }
 	}
 
 # define custom RDF namespaces that can then be used in the mappings below (and will also be used in the output file)


### PR DESCRIPTION
Tässä muutama parannus finaf-dumppia varten. Tuli muuten mieleen, että finaf-lyhenne ei varmaankaan lyhennä mitään siitä syystä, että sen jälkeen on numero heti. Ilmeisesti MTS:n tapauksessa se kuitenkin lyhentää tulevaisuudessa kun siinä on m-kirjain ensimmäisenä lyhenteen jälkeen.